### PR TITLE
Update .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,6 @@ repos:
       - id: debug-statements
       - id: end-of-file-fixer
       - id: check-docstring-first
-      - id: check-added-large-files
       - id: requirements-txt-fixer
       - id: file-contents-sorter
         files: requirements-dev.txt
@@ -73,6 +72,16 @@ repos:
     rev: 0.6.1
     hooks:
     -   id: nbstripout
+        args:
+          [
+            --max-size=1k
+          ]
+
+  # Check on large files as last hook
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-added-large-files
 
   # - repo: https://github.com/pre-commit/mirrors-mypy
   #   rev: v0.770


### PR DESCRIPTION
Using the ``max-size=1k`` flag in nbstripout, only images and text larger than 1KB will be removed. This ensures for informative output cells containing only text not to be modified by ``pre-commit``